### PR TITLE
Change links from AnalyticalGraphicsInc to CesiumGS

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2016-2017 Analytical Graphics, Inc. and Contributors
+Copyright 2016-2020 Cesium GS, Inc. and Contributors
 
                                  Apache License
                            Version 2.0, January 2004
@@ -188,7 +188,7 @@ Copyright 2016-2017 Analytical Graphics, Inc. and Contributors
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016-2017 Analytical Graphics, Inc. and Contributors
+   Copyright 2016-2020 Cesium GS, Inc. and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -233,11 +233,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-### Cesium
+### CesiumJS
 
-http://cesiumjs.org/
+https://cesium.com/cesiumjs/
 
-> Copyright 2011-2016 Cesium Contributors
+> Copyright 2011-2020 CesiumJS Contributors
 >
 > Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 >
@@ -245,7 +245,7 @@ http://cesiumjs.org/
 >
 > Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-See https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
+See https://github.com/CesiumGS/cesium/blob/master/LICENSE.md
 
 ### compression
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<p align="center"><img src="https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/figures/Cesium3DTiles.png" /></p>
+<p align="center"><img src="https://github.com/CesiumGS/3d-tiles/blob/master/figures/Cesium3DTiles.png" /></p>
 
-Sample tilesets for learning how to use [3D Tiles](https://github.com/AnalyticalGraphicsInc/3d-tiles) and a simple Node.js server for serving tilesets.
+Sample tilesets for learning how to use [3D Tiles](https://github.com/CesiumGS/3d-tiles) and a simple Node.js server for serving tilesets.
 
-These tilesets are generated with [3d-tiles-samples-generator](https://github.com/AnalyticalGraphicsInc/3d-tiles-tools/tree/master/samples-generator).
+These tilesets are generated with [3d-tiles-samples-generator](https://github.com/CesiumGS/3d-tiles-validator/tree/master/samples-generator).
 
 ## Instructions
 
@@ -18,7 +18,7 @@ npm start
 
 The tilesets are hosted at `http://localhost:8003/tilesets/`.
 
-To load a tileset with Cesium use:
+To load a tileset with CesiumJS use:
 
 ```javascript
 var viewer = new Cesium.Viewer('cesiumContainer');
@@ -45,4 +45,4 @@ See the `README.md` in each tileset's directory for further instructions and usa
 
 ## Contributions
 
-Pull requests are appreciated!  Please use the same [Contributor License Agreement (CLA)](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md) and [Coding Guide](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Documentation/Contributors/CodingGuide/README.md) used for [Cesium](http://cesiumjs.org/).
+Pull requests are appreciated!  Please use the same [Contributor License Agreement (CLA)](https://github.com/CesiumGS/cesium/blob/master/CONTRIBUTING.md) and [Coding Guide](https://github.com/CesiumGS/cesium/blob/master/Documentation/Contributors/CodingGuide/README.md) used for [CesiumJS](https://cesium.com/cesiumjs/).

--- a/package.json
+++ b/package.json
@@ -4,18 +4,18 @@
   "license": "Apache-2.0",
   "description": "Sample tilesets for learning how to use 3D Tiles.",
   "author": {
-    "name": "Analytical Graphics, Inc. and Contributors"
+    "name": "Cesium GS, Inc. and Contributors"
   },
   "keywords": [
     "3D Tiles"
   ],
-  "homepage": "https://github.com/AnalyticalGraphicsInc/3d-tiles-samples",
+  "homepage": "https://github.com/CesiumGS/3d-tiles-samples",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AnalyticalGraphicsInc/3d-tiles-samples.git"
+    "url": "https://github.com/CesiumGS/3d-tiles-samples.git"
   },
   "bugs": {
-    "url": "https://github.com/AnalyticalGraphicsInc/3d-tiles-samples/issues"
+    "url": "https://github.com/CesiumGS/3d-tiles-samples/issues"
   },
   "main": "index.js",
   "engines": {

--- a/tilesets/TilesetWithDiscreteLOD/README.md
+++ b/tilesets/TilesetWithDiscreteLOD/README.md
@@ -7,8 +7,6 @@ The tileset contains three tiles each with a different decimation of the Stanfor
 
 When a tile's screen space error is met, it is replaced by its higher LOD child.
 
-When running in Cesium, use the `3d-tiles` branch.
-
 ## Screenshot
 
 ![screenshot](screenshot/screenshot.gif)

--- a/tilesets/TilesetWithRequestVolume/README.md
+++ b/tilesets/TilesetWithRequestVolume/README.md
@@ -3,8 +3,6 @@
 The tileset shows off the `requestVolume` property of a tile. When the viewer is inside the request volume of the point cloud, the point cloud is rendered.
 In addition this sample illustrates loading an external tileset from within the main `tileset.json`.
 
-When running in Cesium, use the `3d-tiles-proximity` branch.
-
 The building model was created by Richard Edwards: http://www.blendswap.com/blends/view/45211
 
 ## Screenshot

--- a/tilesets/TilesetWithTreeBillboards/README.md
+++ b/tilesets/TilesetWithTreeBillboards/README.md
@@ -4,8 +4,6 @@ The tileset contains two tiles, one `.i3dm` with full 3D trees, and another `.i3
 
 Note: the billboard effect is coded into the i3dm's embedded glTF model, but a similar effect can be achieved with a vector tile.
 
-When running in Cesium, use the `3d-tiles` branch.
-
 ## Screenshot
 
 ![screenshot](screenshot/screenshot.gif)


### PR DESCRIPTION
Part of the CesiumGS github migration.
See https://groups.google.com/forum/?hl=en#!topic/cesium-dev/5sFSChDEtCg