### PR TITLE
Add licensing information

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Sample tilesets for learning how to use [3D Tiles](https://github.com/CesiumGS/3d-tiles) and a simple Node.js server for serving tilesets.
 
-These tilesets are generated with [3d-tiles-samples-generator](https://github.com/CesiumGS/3d-tiles-validator/tree/master/samples-generator) and are licensed under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+These tilesets are generated with [3d-tiles-samples-generator](https://github.com/CesiumGS/3d-tiles-validator/tree/master/samples-generator). License information can be found in each sample's README.
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Sample tilesets for learning how to use [3D Tiles](https://github.com/CesiumGS/3d-tiles) and a simple Node.js server for serving tilesets.
 
-These tilesets are generated with [3d-tiles-samples-generator](https://github.com/CesiumGS/3d-tiles-validator/tree/master/samples-generator).
+These tilesets are generated with [3d-tiles-samples-generator](https://github.com/CesiumGS/3d-tiles-validator/tree/master/samples-generator) and are licensed under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
 
 ## Instructions
 

--- a/tilesets/TilesetWithDiscreteLOD/README.md
+++ b/tilesets/TilesetWithDiscreteLOD/README.md
@@ -10,3 +10,7 @@ When a tile's screen space error is met, it is replaced by its higher LOD child.
 ## Screenshot
 
 ![screenshot](screenshot/screenshot.gif)
+
+## License
+
+[CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)

--- a/tilesets/TilesetWithExpiration/README.md
+++ b/tilesets/TilesetWithExpiration/README.md
@@ -5,3 +5,7 @@ The tileset contains a single tile with `expire.duration` set to five seconds.
 ## Screenshot
 
 ![screenshot](screenshot/screenshot.gif)
+
+## License
+
+[CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)

--- a/tilesets/TilesetWithRequestVolume/README.md
+++ b/tilesets/TilesetWithRequestVolume/README.md
@@ -3,8 +3,12 @@
 The tileset shows off the `requestVolume` property of a tile. When the viewer is inside the request volume of the point cloud, the point cloud is rendered.
 In addition this sample illustrates loading an external tileset from within the main `tileset.json`.
 
-The building model was created by Richard Edwards: http://www.blendswap.com/blends/view/45211
-
 ## Screenshot
 
 ![screenshot](screenshot/screenshot.gif)
+
+## License
+
+[Creative Commons Attribution 3.0 Unported](https://creativecommons.org/licenses/by/3.0/)
+
+The building model was created by Richard Edwards: http://www.blendswap.com/blends/view/45211

--- a/tilesets/TilesetWithTreeBillboards/README.md
+++ b/tilesets/TilesetWithTreeBillboards/README.md
@@ -7,3 +7,7 @@ Note: the billboard effect is coded into the i3dm's embedded glTF model, but a s
 ## Screenshot
 
 ![screenshot](screenshot/screenshot.gif)
+
+## License
+
+[CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)


### PR DESCRIPTION
Adds licensing information to each tileset. All are CC0 except `TilesetWithRequestVolume` which is CC3 like the source model.

CC https://github.com/CesiumGS/3d-tiles-validator/pull/200