### PR TITLE
Fixed declarations of used and required extensions

### DIFF
--- a/next/ImplicitTilesetWithTileMetadata/tileset.json
+++ b/next/ImplicitTilesetWithTileMetadata/tileset.json
@@ -3,9 +3,12 @@
     "version": "1.0"
   },
   "extensionsUsed": [
+    "3DTILES_metadata",
+    "3DTILES_content_gltf",
     "3DTILES_implicit_tiling"
   ],
   "extensionsRequired": [
+    "3DTILES_content_gltf",
     "3DTILES_implicit_tiling"
   ],
   "extensions": {

--- a/next/TilesetWithExternalSchema/tileset.json
+++ b/next/TilesetWithExternalSchema/tileset.json
@@ -4,10 +4,11 @@
     "tilesetVersion": "1.2.3"
   },
   "extensionsUsed": [
-    "3DTILES_metadata"
+    "3DTILES_metadata",
+    "3DTILES_content_gltf"
   ],
   "extensionsRequired": [
-    "3DTILES_metadata"
+    "3DTILES_content_gltf"
   ],
   "extensions": {
     "3DTILES_metadata": {

--- a/next/TilesetWithGroupMetadata/tileset.json
+++ b/next/TilesetWithGroupMetadata/tileset.json
@@ -4,7 +4,11 @@
     "tilesetVersion": "1.2.3"
   },
   "extensionsUsed": [
-    "3DTILES_metadata"
+    "3DTILES_metadata",
+    "3DTILES_content_gltf"
+  ],
+  "extensionsRequired": [
+    "3DTILES_content_gltf"
   ],
   "extensions": {
     "3DTILES_metadata": {

--- a/next/TilesetWithTileMetadata/tileset.json
+++ b/next/TilesetWithTileMetadata/tileset.json
@@ -4,7 +4,11 @@
     "tilesetVersion": "1.2.3"
   },
   "extensionsUsed": [
-    "3DTILES_metadata"
+    "3DTILES_metadata",
+    "3DTILES_content_gltf"
+  ],
+  "extensionsRequired": [
+    "3DTILES_content_gltf"
   ],
   "extensions": {
     "3DTILES_metadata": {

--- a/next/TilesetWithTilesetMetadata/tileset.json
+++ b/next/TilesetWithTilesetMetadata/tileset.json
@@ -4,10 +4,11 @@
     "tilesetVersion": "1.2.3"
   },
   "extensionsUsed": [
-    "3DTILES_metadata"
+    "3DTILES_metadata",
+    "3DTILES_content_gltf"
   ],
   "extensionsRequired": [
-    "3DTILES_metadata"
+    "3DTILES_content_gltf"
   ],
   "extensions": {
     "3DTILES_metadata": {


### PR DESCRIPTION
This should fix https://github.com/CesiumGS/3d-tiles-samples/issues/35

- It adds the `3DTILES_content_gltf` to all tilesets that use glTF content
- It removes `3DTILES_metadata` from `extensionsRequired` because ... it should not be required, according to the spec...!?
- It adds `3D_TILES_metadata` to the `extensionsUsed` in the implicit tiling example, where it was used, but not declared


