### PR TITLE
Removed group ID from MetadataGranularities

### DIFF
--- a/1.1/MetadataGranularities/tileset.json
+++ b/1.1/MetadataGranularities/tileset.json
@@ -77,15 +77,13 @@
     "properties" : {
       "color" : [ 64, 64, 255 ],
       "priority" : 1
-    },
-    "id" : "buildings"
+    }
   }, {
     "class" : "exampleGroupMetadataClass",
     "properties" : {
       "color" : [ 64, 255, 64 ],
       "priority" : 2
-    },
-    "id" : "trees"
+    }
   } ],
   "metadata" : {
     "class" : "exampleTilesetMetadataClass",


### PR DESCRIPTION
Removed the `group.id`, which has been removed in the spec via https://github.com/CesiumGS/3d-tiles/pull/678 