### PR TITLE
Added featureCount to EXT_mesh_features samples

### DIFF
--- a/glTF/EXT_mesh_features/FeatureIdAttribute/FeatureIdAttribute.gltf
+++ b/glTF/EXT_mesh_features/FeatureIdAttribute/FeatureIdAttribute.gltf
@@ -77,6 +77,7 @@
       "extensions" : {
         "EXT_mesh_features" : {
           "featureIds" : [ {
+            "featureCount" : 4,
             "attribute" : 0
           } ]
         }

--- a/glTF/EXT_mesh_features/FeatureIdTexture/FeatureIdTexture.gltf
+++ b/glTF/EXT_mesh_features/FeatureIdTexture/FeatureIdTexture.gltf
@@ -87,6 +87,7 @@
       "extensions" : {
         "EXT_mesh_features" : {
           "featureIds" : [ {
+            "featureCount" : 4,
             "texture" : {
               "index" : 1,
               "texCoord" : 0,

--- a/glTF/EXT_structural_metadata/ComplexTypes/ComplexTypes.gltf
+++ b/glTF/EXT_structural_metadata/ComplexTypes/ComplexTypes.gltf
@@ -187,6 +187,7 @@
       "extensions" : {
         "EXT_mesh_features" : {
           "featureIds" : [ {
+            "featureCount" : 4,
             "attribute" : 0,
             "propertyTable" : 0
           } ]

--- a/glTF/EXT_structural_metadata/FeatureIdAttributeAndPropertyTable/FeatureIdAttributeAndPropertyTable.gltf
+++ b/glTF/EXT_structural_metadata/FeatureIdAttributeAndPropertyTable/FeatureIdAttributeAndPropertyTable.gltf
@@ -114,6 +114,7 @@
       "extensions" : {
         "EXT_mesh_features" : {
           "featureIds" : [ {
+            "featureCount" : 4,
             "attribute" : 0,
             "propertyTable" : 0
           } ]

--- a/glTF/EXT_structural_metadata/FeatureIdTextureAndPropertyTable/FeatureIdTextureAndPropertyTable.gltf
+++ b/glTF/EXT_structural_metadata/FeatureIdTextureAndPropertyTable/FeatureIdTextureAndPropertyTable.gltf
@@ -138,6 +138,7 @@
       "extensions" : {
         "EXT_mesh_features" : {
           "featureIds" : [ {
+            "featureCount" : 4,
             "texture" : {
               "index" : 1,
               "texCoord" : 0,

--- a/glTF/EXT_structural_metadata/MultipleClasses/MultipleClasses.gltf
+++ b/glTF/EXT_structural_metadata/MultipleClasses/MultipleClasses.gltf
@@ -196,9 +196,11 @@
       "extensions" : {
         "EXT_mesh_features" : {
           "featureIds" : [ {
+            "featureCount" : 4,
             "attribute" : 0,
             "propertyTable" : 0
           }, {
+            "featureCount" : 4,
             "attribute" : 1,
             "propertyTable" : 1
           } ]

--- a/glTF/EXT_structural_metadata/MultipleFeatureIdsAndProperties/MultipleFeatureIdsAndProperties.gltf
+++ b/glTF/EXT_structural_metadata/MultipleFeatureIdsAndProperties/MultipleFeatureIdsAndProperties.gltf
@@ -145,9 +145,11 @@
       "extensions" : {
         "EXT_mesh_features" : {
           "featureIds" : [ {
+            "featureCount" : 4,
             "attribute" : 0,
             "propertyTable" : 0
           }, {
+            "featureCount" : 4,
             "attribute" : 1,
             "propertyTable" : 0
           } ]

--- a/glTF/EXT_structural_metadata/SharedPropertyTable/SharedPropertyTable.gltf
+++ b/glTF/EXT_structural_metadata/SharedPropertyTable/SharedPropertyTable.gltf
@@ -175,6 +175,7 @@
       "extensions" : {
         "EXT_mesh_features" : {
           "featureIds" : [ {
+            "featureCount" : 4,
             "attribute" : 0,
             "propertyTable" : 0
           } ]
@@ -192,6 +193,7 @@
       "extensions" : {
         "EXT_mesh_features" : {
           "featureIds" : [ {
+            "featureCount" : 4,
             "attribute" : 0,
             "propertyTable" : 0
           } ]


### PR DESCRIPTION
The property is [required as of `featureId.schema.json`](https://github.com/CesiumGS/glTF/blob/e3d043eae175b2bc746b5dcbbd8f1c7a63f90090/extensions/2.0/Vendor/EXT_mesh_features/schema/featureId.schema.json#L45).

---

I wondered about the implications for clients that want to create these assets. Specifically, it is not possible to say: "Here's some random PNG file, use this as the feature ID texture". So the texture itself (i.e. the PNG file) and the actual glTF asset cannot be created independently. 

("Not possible" here means: It is not possible _without_ loading the image and counting how many different pixels it contains. That's what I'm doing in my implementation right now, but it feels a bit brittle. However, other implementations might track the `featureCount` during the whole creation process, and may be able to put that information into the final asset directly...)

