### PR TITLE
Update method name for property IDs

### DIFF
--- a/glTF/glTF-Structural-Metadata-Samples-Sandcastle.js
+++ b/glTF/glTF-Structural-Metadata-Samples-Sandcastle.js
@@ -66,7 +66,7 @@ function createFeatureHtml(title, feature) {
   if (!Cesium.defined(feature)) {
     return `(No ${title})<br>`;
   }
-  const propertyKeys = feature.getPropertyNames();
+  const propertyKeys = feature.getPropertyIds();
   if (!Cesium.defined(propertyKeys)) {
     return `(No properties for ${title})<br>`;
   }


### PR DESCRIPTION
A small update of the method name in the sandcastle code, to take https://github.com/CesiumGS/cesium/pull/10473 into account (the old one caused a deprecation message)
