### PR TITLE
Fix links to 3D Tiles specification

### DIFF
--- a/1.1/MetadataGranularities/README.md
+++ b/1.1/MetadataGranularities/README.md
@@ -1,6 +1,6 @@
 # Metadata Granularities
 
-This sample demonstrates the use of [Metadata in 3D Tiles 1.1](https://github.com/CesiumGS/3d-tiles/blob/draft-1.1/specification) on different levels of granularity. The sample consists of a tileset with 4 tiles where each tile has 5 contents, and the contents are assigned to two different groups. Metadata is assigned to the tileset, the tiles, each content, and to the groups.
+This sample demonstrates the use of [Metadata in 3D Tiles 1.1](https://github.com/CesiumGS/3d-tiles/blob/main/specification) on different levels of granularity. The sample consists of a tileset with 4 tiles where each tile has 5 contents, and the contents are assigned to two different groups. Metadata is assigned to the tileset, the tiles, each content, and to the groups.
 
 ## Screenshot
 

--- a/1.1/SparseImplicitOctree/README.md
+++ b/1.1/SparseImplicitOctree/README.md
@@ -1,7 +1,7 @@
 
 # Sparse implicit octree
 
-An example tileset that uses the [Implicit Tiling](https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/ImplicitTiling) to represent a small, sparse octree. 
+An example tileset that uses the [Implicit Tiling](https://github.com/CesiumGS/3d-tiles/tree/main/specification/ImplicitTiling) to represent a small, sparse octree. 
 
 The quadtree has 6 available levels, and each subtree has 3 levels. There are 31 tiles with content in the tree: 
 

--- a/1.1/SparseImplicitQuadtree/README.md
+++ b/1.1/SparseImplicitQuadtree/README.md
@@ -1,7 +1,7 @@
 
 # Sparse implicit quadtree
 
-An example tileset that uses the [Implicit Tiling](https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/ImplicitTiling) to represent a small, sparse quadtree. 
+An example tileset that uses the [Implicit Tiling](https://github.com/CesiumGS/3d-tiles/tree/main/specification/ImplicitTiling) to represent a small, sparse quadtree. 
 
 The quadtree has 6 available levels, and each subtree has 3 levels. There are 32 tiles available in level 5. Each of these tiles has a content, which is a simple glTF asset as a GLB (glTF binary) file that just consists of a portion of the unit square that corresponds to the extent of the respective tile. No other tiles - except for the ones that have content, and their respective ancestors - are available. 
 

--- a/1.1/TilesetWithFullMetadata/README.md
+++ b/1.1/TilesetWithFullMetadata/README.md
@@ -1,6 +1,6 @@
 # Tileset with full Metadata
 
-This sample demonstrates the types of metadata that may be associated with entities, based on the type system that is defined in the [3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/Metadata).
+This sample demonstrates the types of metadata that may be associated with entities, based on the type system that is defined in the [3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata).
 
 ![TilesetWithFullsetMetadata](screenshot/TilesetWithFullMetadata.png)
 

--- a/glTF/EXT_structural_metadata/PropertyAttributesPointCloud/README.md
+++ b/glTF/EXT_structural_metadata/PropertyAttributesPointCloud/README.md
@@ -4,7 +4,7 @@ An example that shows how to combine different features of the `EXT_structural_m
 
 ### Sharing a metadata schema between glTF assets and a 3D Tiles tileset
 
-The example uses a single metadata schema, as defined in the [3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/Metadata). The schema is stored in a `MetadataSchema.json` file, and defines a metadata class with two properties:
+The example uses a single metadata schema, as defined in the [3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata). The schema is stored in a `MetadataSchema.json` file, and defines a metadata class with two properties:
 
 - an `intensity` property, which is a single floating point value
 - a `classification` property, which is an enum with `MediumVegetation` and `Buildings` as its values
@@ -17,7 +17,7 @@ The glTF assets are simple point clouds, with [property attributes](https://gith
 
 ### Defining statistics for the metadata values
 
-The 3D Tiles tileset contains [metadata statistics](https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification#metadata-statistics) for the metadata from the glTF assets. These statistics contain, for example, the minimum and maximum `intensity` value, and the number of occurences for each `classification` value.
+The 3D Tiles tileset contains [metadata statistics](https://github.com/CesiumGS/3d-tiles/tree/main/specification#metadata-statistics) for the metadata from the glTF assets. These statistics contain, for example, the minimum and maximum `intensity` value, and the number of occurences for each `classification` value.
 
 ## Screenshot
 


### PR DESCRIPTION
The `draft-1.1` branch of the 3D Tiles specification has been merged into `main`. This PR updates the links accordingly.