### PR TITLE
Add missing schema IDs to glTF samples

### DIFF
--- a/glTF/EXT_structural_metadata/FeatureIdAttributeAndPropertyTable/FeatureIdAttributeAndPropertyTable.gltf
+++ b/glTF/EXT_structural_metadata/FeatureIdAttributeAndPropertyTable/FeatureIdAttributeAndPropertyTable.gltf
@@ -2,6 +2,7 @@
   "extensions" : {
     "EXT_structural_metadata" : {
       "schema" : {
+        "id": "FeatureIdAttributeAndPropertyTableSchema",
         "classes" : {
           "exampleMetadataClass" : {
             "name" : "Example metadata class",

--- a/glTF/EXT_structural_metadata/FeatureIdTextureAndPropertyTable/FeatureIdTextureAndPropertyTable.gltf
+++ b/glTF/EXT_structural_metadata/FeatureIdTextureAndPropertyTable/FeatureIdTextureAndPropertyTable.gltf
@@ -2,6 +2,7 @@
   "extensions" : {
     "EXT_structural_metadata" : {
       "schema" : {
+        "id": "FeatureIdTextureAndPropertyTableSchema",
         "classes" : {
           "buildingComponents" : {
             "name" : "Building components",

--- a/glTF/EXT_structural_metadata/MultipleClasses/MultipleClasses.gltf
+++ b/glTF/EXT_structural_metadata/MultipleClasses/MultipleClasses.gltf
@@ -2,6 +2,7 @@
   "extensions" : {
     "EXT_structural_metadata" : {
       "schema" : {
+        "id": "MultipleClassesSchema",
         "classes" : {
           "exampleMetadataClassA" : {
             "name" : "Example metadata class A",

--- a/glTF/EXT_structural_metadata/MultipleFeatureIdsAndProperties/MultipleFeatureIdsAndProperties.gltf
+++ b/glTF/EXT_structural_metadata/MultipleFeatureIdsAndProperties/MultipleFeatureIdsAndProperties.gltf
@@ -2,6 +2,7 @@
   "extensions" : {
     "EXT_structural_metadata" : {
       "schema" : {
+        "id": "MultipleFeatureIdsAndPropertiesSchema",
         "classes" : {
           "exampleMetadataClass" : {
             "name" : "Example metadata class",

--- a/glTF/EXT_structural_metadata/SharedPropertyTable/SharedPropertyTable.gltf
+++ b/glTF/EXT_structural_metadata/SharedPropertyTable/SharedPropertyTable.gltf
@@ -2,6 +2,7 @@
   "extensions" : {
     "EXT_structural_metadata" : {
       "schema" : {
+        "id": "SharedPropertyTableSchema",
         "classes" : {
           "exampleMetadataClass" : {
             "name" : "Example metadata class",

--- a/glTF/EXT_structural_metadata/SimplePropertyTexture/SimplePropertyTexture.gltf
+++ b/glTF/EXT_structural_metadata/SimplePropertyTexture/SimplePropertyTexture.gltf
@@ -2,6 +2,7 @@
   "extensions" : {
     "EXT_structural_metadata" : {
       "schema" : {
+        "id": "SimplePropertyTextureSchema",
         "classes" : {
           "buildingComponents" : {
             "name" : "Building properties",

--- a/glTF/GpuInstancesMetadata/GpuInstancesMetadata.gltf
+++ b/glTF/GpuInstancesMetadata/GpuInstancesMetadata.gltf
@@ -2,6 +2,7 @@
   "extensions" : {
     "EXT_structural_metadata" : {
       "schema" : {
+        "id": "GpuInstancesMetadataSchema",
         "classes" : {
           "exampleMetadataClass" : {
             "name" : "Example metadata class",


### PR DESCRIPTION
The `id` property of the metadata schema is [required according to `schema.schema.json`](https://github.com/CesiumGS/glTF/blob/c38f7f37e894004353c15cd0481bc5b7381ce841/extensions/2.0/Vendor/EXT_structural_metadata/schema/schema.schema.json#L53), but was missing in the glTF samples.
