### PR TITLE
Add missing refine property

### DIFF
--- a/1.1/MultipleContents/tileset.json
+++ b/1.1/MultipleContents/tileset.json
@@ -16,6 +16,7 @@
         0.0, -0.5, 0.0, 
         0.0, 0.0, 0.1 ]
     },
-    "geometricError" : 1.0
+    "geometricError" : 1.0,
+    "refine" : "REPLACE"
   }
 }

--- a/1.1/TilesetWithFullMetadata/tileset.json
+++ b/1.1/TilesetWithFullMetadata/tileset.json
@@ -3634,6 +3634,7 @@
     "boundingVolume" : {
       "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
     },
-    "geometricError" : 1.0
+    "geometricError" : 1.0,
+    "refine" : "REPLACE"
   }
 }

--- a/glTF/CESIUM_primitive_outline/BoxPrimitiveOutline/tileset.json
+++ b/glTF/CESIUM_primitive_outline/BoxPrimitiveOutline/tileset.json
@@ -13,6 +13,7 @@
       ]
     },
     "geometricError" : 1.0,
+    "refine" : "REPLACE",
     "content": {
       "uri": "BoxPrimitiveOutline.gltf"
     }

--- a/glTF/EXT_mesh_features/FeatureIdAttribute/tileset.json
+++ b/glTF/EXT_mesh_features/FeatureIdAttribute/tileset.json
@@ -14,6 +14,7 @@
         0.0, 0.01, 0.0, 
         0.0, 0.0, 0.5]
     },
-    "geometricError" : 0.0
+    "geometricError" : 0.0,
+    "refine" : "REPLACE"
   }
 }

--- a/glTF/EXT_mesh_features/FeatureIdTexture/tileset.json
+++ b/glTF/EXT_mesh_features/FeatureIdTexture/tileset.json
@@ -14,6 +14,7 @@
         0.0, 0.01, 0.0, 
         0.0, 0.0, 0.5]
     },
-    "geometricError" : 0.0
+    "geometricError" : 0.0,
+    "refine" : "REPLACE"
   }
 }

--- a/glTF/EXT_structural_metadata/ComplexTypes/tileset.json
+++ b/glTF/EXT_structural_metadata/ComplexTypes/tileset.json
@@ -14,6 +14,7 @@
         0.0, 0.01, 0.0, 
         0.0, 0.0, 0.5]
     },
-    "geometricError" : 0.0
+    "geometricError" : 0.0,
+    "refine" : "REPLACE"
   }
 }

--- a/glTF/EXT_structural_metadata/FeatureIdAttributeAndPropertyTable/tileset.json
+++ b/glTF/EXT_structural_metadata/FeatureIdAttributeAndPropertyTable/tileset.json
@@ -14,6 +14,7 @@
         0.0, 0.01, 0.0, 
         0.0, 0.0, 0.5]
     },
-    "geometricError" : 0.0
+    "geometricError" : 0.0,
+    "refine" : "REPLACE"
   }
 }

--- a/glTF/EXT_structural_metadata/FeatureIdTextureAndPropertyTable/tileset.json
+++ b/glTF/EXT_structural_metadata/FeatureIdTextureAndPropertyTable/tileset.json
@@ -14,6 +14,7 @@
         0.0, 0.01, 0.0, 
         0.0, 0.0, 0.5]
     },
-    "geometricError" : 0.0
+    "geometricError" : 0.0,
+    "refine" : "REPLACE"
   }
 }

--- a/glTF/EXT_structural_metadata/MultipleClasses/tileset.json
+++ b/glTF/EXT_structural_metadata/MultipleClasses/tileset.json
@@ -14,6 +14,7 @@
         0.0, 0.01, 0.0, 
         0.0, 0.0, 0.5]
     },
-    "geometricError" : 0.0
+    "geometricError" : 0.0,
+    "refine" : "REPLACE"
   }
 }

--- a/glTF/EXT_structural_metadata/MultipleFeatureIdsAndProperties/tileset.json
+++ b/glTF/EXT_structural_metadata/MultipleFeatureIdsAndProperties/tileset.json
@@ -14,6 +14,7 @@
         0.0, 0.01, 0.0, 
         0.0, 0.0, 0.5]
     },
-    "geometricError" : 0.0
+    "geometricError" : 0.0,
+    "refine" : "REPLACE"
   }
 }

--- a/glTF/EXT_structural_metadata/SharedPropertyTable/tileset.json
+++ b/glTF/EXT_structural_metadata/SharedPropertyTable/tileset.json
@@ -14,6 +14,7 @@
         0.0, 0.01, 0.0, 
         0.0, 0.0, 0.5]
     },
-    "geometricError" : 0.0
+    "geometricError" : 0.0,
+    "refine" : "REPLACE"
   }
 }

--- a/glTF/EXT_structural_metadata/SimplePropertyTexture/tileset.json
+++ b/glTF/EXT_structural_metadata/SimplePropertyTexture/tileset.json
@@ -14,6 +14,7 @@
         0.0, 0.01, 0.0,
         0.0, 0.0, 0.5]
     },
-    "geometricError" : 0.0
+    "geometricError" : 0.0,
+    "refine" : "REPLACE"
   }
 }

--- a/glTF/GpuInstancesMetadata/tileset.json
+++ b/glTF/GpuInstancesMetadata/tileset.json
@@ -15,6 +15,7 @@
          0.0, 0.0, 5.8532143
       ]
     },
-    "geometricError" : 0.0
+    "geometricError" : 0.0,
+    "refine" : "REPLACE"
   }
 }


### PR DESCRIPTION
A refinement type is required for the root tile of a tileset.

> A refinement type is required for the root tile of a tileset; it is optional for all other tiles. When omitted, a tile inherits the refinement type of its parent.

https://github.com/CesiumGS/3d-tiles/tree/main/specification#refinement